### PR TITLE
Docs: 'sklearn' is deprecated, use 'scikit-learn' instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You may use the following commands to install GOSDT along with its dependencies 
 You need **Python 3.7 or later** to use the module `gosdt` in your project.
 
 ```bash
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 pip3 install osrt
 ```
 

--- a/README_PyPI.md
+++ b/README_PyPI.md
@@ -18,7 +18,7 @@ You may use the following commands to install GOSDT along with its dependencies 
 You need **Python 3.7 or later** to use the module `gosdt` in your project.
 
 ```bash
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 pip3 install osrt
 ```
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -272,13 +272,13 @@ Please adjust the name of your wheel file accordingly.
 
 ```bash
 pip3 install dist/osrt-0.1.0-cp310-cp310-macosx_12_0_x86_64.whl
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 python3 osrt/example.py
 ```
 
 If you are using macOS 11.0 or higher, and python 3.7 or 3.8.
 ```bash
 SYSTEM_VERSION_COMPAT=0 pip3 install dist/osrt-0.1.0-cp38-abi3-macosx_13_0_x86_64.whl
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 python3 osrt/example.py
 ```

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
                       "packaging>=20.9",
                       "editables==0.2;python_version>'3.0'",
                       "pandas",
-                      "sklearn",
+                      "scikit-learn",
                       "sortedcontainers",
                       "gmpy2",
                       "matplotlib"


### PR DESCRIPTION
'pip install sklearn' fails on recent Python/pip versions.